### PR TITLE
Address failures in flowsheet serialization tests refer to #19

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 --editable .[dev]
 idaes-pse @ git+https://github.com/IDAES/idaes-pse@main
+pytest-icdiff >= 0.7  # readable dict diffs for test_flowsheet and others


### PR DESCRIPTION
### Proposed changes:
#### This PR addresses to fix PR #19 
* Refactor (via pytest.mark.parametrize) the flowsheet serialization tests
* Add [pytest-icdiff](https://pypi.org/project/pytest-icdiff/), a pytest plugin that improves the assertion failure display for nested dicts by showing a side-by-side rich diff of the changes

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
